### PR TITLE
Remove MAKE gsl docs

### DIFF
--- a/libs/gsl-1.15/Makefile
+++ b/libs/gsl-1.15/Makefile
@@ -311,7 +311,7 @@ target_alias =
 top_build_prefix = 
 top_builddir = .
 top_srcdir = .
-SUBDIRS = gsl utils sys test err const complex cheb block vector matrix permutation combination multiset sort ieee-utils cblas blas linalg eigen specfunc dht qrng rng randist fft poly fit multifit statistics siman sum integration interpolation histogram ode-initval ode-initval2 roots multiroots min multimin monte ntuple diff deriv cdf wavelet bspline doc
+SUBDIRS = gsl utils sys test err const complex cheb block vector matrix permutation combination multiset sort ieee-utils cblas blas linalg eigen specfunc dht qrng rng randist fft poly fit multifit statistics siman sum integration interpolation histogram ode-initval ode-initval2 roots multiroots min multimin monte ntuple diff deriv cdf wavelet bspline
 SUBLIBS = block/libgslblock.la blas/libgslblas.la \
 	bspline/libgslbspline.la complex/libgslcomplex.la \
 	cheb/libgslcheb.la dht/libgsldht.la diff/libgsldiff.la \


### PR DESCRIPTION
Making GSL docs depends has a dependency on makeinfo which comes as part of tex which is a bit of a nightmare to install if you don't already have it. 

Since CORTEX doesn't depend on the gsl docs removing this makes initial install easier.